### PR TITLE
Allow developers to use a custom font as well as FontAwesome font.

### DIFF
--- a/Example/FontAwesome-iOS-Demo/ViewController.m
+++ b/Example/FontAwesome-iOS-Demo/ViewController.m
@@ -26,13 +26,26 @@
     
     // UIImage Example:
     // NOTE: The image methods only work if your app's base sdk is iOS 6+.
-    UIImage *icon = [FontAwesome imageWithIcon:fa_cutlery iconColor:[UIColor redColor]
+    UIImage *icon = [FontAwesome imageWithIcon:fa_cutlery
+                                     iconColor:[UIColor redColor]
                                       iconSize:60.0f
                                      imageSize:CGSizeMake(90.0f, 90.0f)];
     UIImageView *img = [[UIImageView alloc] initWithImage:icon];
     img.center = self.view.center;
     img.backgroundColor = [UIColor lightGrayColor];
     [self.view addSubview:img];
+
+    // UIImage Example:
+    // NOTE: The image methods only work if your app's base sdk is iOS 6+.
+    UIImage *icon2 = [FontAwesome imageWithText:@"\uf190"
+                                           font:@"FontAwesome"  // or your custom font here
+                                      iconColor:[UIColor redColor]
+                                       iconSize:60.0f
+                                      imageSize:CGSizeMake(90.0f, 90.0f)];
+    UIImageView *img2 = [[UIImageView alloc] initWithImage:icon2];
+    img2.center = CGPointMake(160, 360);
+    img2.backgroundColor = [UIColor lightGrayColor];
+    [self.view addSubview:img2];
 }
 
 @end

--- a/FontAwesomeTools/FontAwesome.h
+++ b/FontAwesomeTools/FontAwesome.h
@@ -24,6 +24,10 @@
                      size:(CGFloat)size
                     color:(UIColor*)color;
 
+/*  Convenience method to get a custom font.
+ */
++ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size;
+
 
 //================================
 // Image Methods
@@ -41,5 +45,14 @@
                 iconColor:(UIColor*)color
                  iconSize:(CGFloat)iconSize
                 imageSize:(CGSize)imageSize;
+
+/* The image and the icon inside it can be from a custom font:
+ */
++ (UIImage*)imageWithFontNamed:(NSString*)font
+                          icon:(NSString*)fa_icon
+                     iconColor:(UIColor*)iconColor
+                      iconSize:(CGFloat)iconSize
+                     imageSize:(CGSize)imageSize;
+
 
 @end

--- a/FontAwesomeTools/FontAwesome.h
+++ b/FontAwesomeTools/FontAwesome.h
@@ -18,15 +18,15 @@
  */
 + (UIFont*)fontWithSize:(CGFloat)size;
 
+/*  Convenience method to get a custom font.
+ */
++ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size;
+
 /*  Convenience method to make a sized-to-fit UILabel containing an icon in the given font size and color.
  */
 + (UILabel*)labelWithIcon:(NSString*)fa_icon
                      size:(CGFloat)size
                     color:(UIColor*)color;
-
-/*  Convenience method to get a custom font.
- */
-+ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size;
 
 
 //================================
@@ -48,11 +48,11 @@
 
 /* The image and the icon inside it can be from a custom font:
  */
-+ (UIImage*)imageWithFontNamed:(NSString*)font
-                          icon:(NSString*)fa_icon
-                     iconColor:(UIColor*)iconColor
-                      iconSize:(CGFloat)iconSize
-                     imageSize:(CGSize)imageSize;
++ (UIImage*)imageWithText:(NSString*)characterCodeString
+                     font:(NSString*)font
+                iconColor:(UIColor*)iconColor
+                 iconSize:(CGFloat)iconSize
+                imageSize:(CGSize)imageSize;
 
 
 @end

--- a/FontAwesomeTools/FontAwesome.m
+++ b/FontAwesomeTools/FontAwesome.m
@@ -13,7 +13,7 @@
 // Font and Label Methods
 //================================
 
-+ (UIFont*)fontWithSize:(CGFloat)size;
++ (UIFont*)fontWithSize:(CGFloat)size
 {
     return [UIFont fontWithName:@"FontAwesome" size:size];
 }
@@ -32,6 +32,12 @@
     label.accessibilityElementsHidden = YES;
     return label;
 }
+
++ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size
+{
+    return [UIFont fontWithName:font size:size];
+}
+
 
 
 //================================
@@ -53,6 +59,19 @@
                  iconSize:(CGFloat)iconSize
                 imageSize:(CGSize)imageSize;
 {
+    return [self imageWithFontNamed:@"FontAwesome"
+                               icon:fa_icon
+                          iconColor:iconColor
+                           iconSize:iconSize
+                          imageSize:imageSize];
+}
+
++ (UIImage*)imageWithFontNamed:(NSString*)font
+                          icon:(NSString*)fa_icon
+                     iconColor:(UIColor*)iconColor
+                      iconSize:(CGFloat)iconSize
+                     imageSize:(CGSize)imageSize;
+{
     NSAssert(fa_icon, @"You must specify an icon from font-awesome-codes.h.");
     
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6) {
@@ -61,7 +80,7 @@
         UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0.0);
         NSAttributedString* attString = [[NSAttributedString alloc]
                                          initWithString:fa_icon
-                                         attributes:@{NSFontAttributeName: [FontAwesome fontWithSize:iconSize],
+                                         attributes:@{NSFontAttributeName: [FontAwesome fontNamed:font withSize:iconSize],
                                                       NSForegroundColorAttributeName : iconColor}];
         // get the target bounding rect in order to center the icon within the UIImage:
         NSStringDrawingContext *ctx = [[NSStringDrawingContext alloc] init];

--- a/FontAwesomeTools/FontAwesome.m
+++ b/FontAwesomeTools/FontAwesome.m
@@ -18,6 +18,11 @@
     return [UIFont fontWithName:@"FontAwesome" size:size];
 }
 
++ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size
+{
+    return [UIFont fontWithName:font size:size];
+}
+
 + (UILabel*)labelWithIcon:(NSString*)fa_icon
                      size:(CGFloat)size
                     color:(UIColor*)color
@@ -31,11 +36,6 @@
     // NOTE: FontAwesome will be silent through VoiceOver, but the Label is still selectable through VoiceOver. This can cause a usability issue because a visually impaired user might navigate to the label but get no audible feedback that the navigation happened. So hide the label for VoiceOver by default - if your label should be descriptive, un-hide it explicitly after creating it, and then set its accessibiltyLabel.
     label.accessibilityElementsHidden = YES;
     return label;
-}
-
-+ (UIFont*)fontNamed:(NSString*)font withSize:(CGFloat)size
-{
-    return [UIFont fontWithName:font size:size];
 }
 
 
@@ -59,27 +59,28 @@
                  iconSize:(CGFloat)iconSize
                 imageSize:(CGSize)imageSize;
 {
-    return [self imageWithFontNamed:@"FontAwesome"
-                               icon:fa_icon
-                          iconColor:iconColor
-                           iconSize:iconSize
-                          imageSize:imageSize];
+    NSAssert(fa_icon, @"You must specify an icon from font-awesome-codes.h.");
+    return [self imageWithText:fa_icon
+                          font:@"FontAwesome"
+                     iconColor:iconColor
+                      iconSize:iconSize
+                     imageSize:imageSize];
 }
 
-+ (UIImage*)imageWithFontNamed:(NSString*)font
-                          icon:(NSString*)fa_icon
-                     iconColor:(UIColor*)iconColor
-                      iconSize:(CGFloat)iconSize
-                     imageSize:(CGSize)imageSize;
++ (UIImage*)imageWithText:(NSString*)characterCodeString
+                     font:(NSString*)font
+                iconColor:(UIColor*)iconColor
+                 iconSize:(CGFloat)iconSize
+                imageSize:(CGSize)imageSize;
 {
-    NSAssert(fa_icon, @"You must specify an icon from font-awesome-codes.h.");
-    
+    NSAssert(characterCodeString, @"You must specify a character code, such as \\uf190.");
+
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6) {
         if (!iconColor) { iconColor = [UIColor blackColor]; }
         
         UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0.0);
         NSAttributedString* attString = [[NSAttributedString alloc]
-                                         initWithString:fa_icon
+                                         initWithString:characterCodeString
                                          attributes:@{NSFontAttributeName: [FontAwesome fontNamed:font withSize:iconSize],
                                                       NSForegroundColorAttributeName : iconColor}];
         // get the target bounding rect in order to center the icon within the UIImage:
@@ -97,7 +98,7 @@
 #if DEBUG
         NSLog(@" [ FontAwesomeTools ] Using lower-res iOS 5-compatible image rendering.");
 #endif
-        UILabel *iconLabel = [FontAwesome labelWithIcon:fa_icon size:iconSize color:iconColor];
+        UILabel *iconLabel = [FontAwesome labelWithIcon:characterCodeString size:iconSize color:iconColor];
         UIImage *iconImage = nil;
         UIGraphicsBeginImageContextWithOptions(imageSize, NO, 1.0);
         {


### PR DESCRIPTION
Dave Grady, I don't know if you are open to pull requests on this, but I found your library today and would like to use it intact as a cocoapod.  I need the flexibility to specify my own custom font when an image that I need isn't in FontAwesome.  I didn't see how I could enable this by subclassing.  Maybe a few other developers would like the option as well.
-Doug Ivers
